### PR TITLE
fix(sync): remove push force

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -212,12 +212,11 @@ create_pr_for_template() {
         git branch $branch
     fi
     git checkout $branch
-    git reset --hard master
 
     git stash pop
     git add $template_path
     git commit -m "(auto) Changes in $template"
-    git push -f origin $branch
+    git push origin $branch
 
     echo ${GITHUB_TOKEN} | gh auth login --with-token
     gh pr create -d --title "(auto) Publish template: $template." --body "Detected changes in template $template. Review this PR to approve."


### PR DESCRIPTION
Is not really necessary to reset to master to apply the stash, as we are applying not conflicting folders the stash will silently fail with no changes if there is nothing new. This way we can push without force preventing updates to every pr every hour

## Context
Ayer hice merge de este PR #5, quedo funcionando bien, pero es medio feo ese push force, que actualiza el pr cada una hora.
Con este cambio, si un PR no se ha mergeado y hay nuevos cambios, van a haber nuevos commits agregados, lo que esta bien igual.