### PR TITLE
fix(setup_git): add exception for safe directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -182,6 +182,7 @@ apply() {
 }
 
 setup_git() {
+    git config --global --add safe.directory /github/workspace
     git pull --unshallow
     git config --global user.email $committer_email
     git config --global user.name $committer_name

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -182,7 +182,7 @@ apply() {
 }
 
 setup_git() {
-    git config --global --add safe.directory /github/workspace
+    git config --global --add safe.directory $GITHUB_WORKSPACE
     git pull --unshallow
     git config --global user.email $committer_email
     git config --global user.name $committer_name


### PR DESCRIPTION
Al parecer una actualización de seguridad hizo que este action fallara, desde abril. Se aplica este workaround: https://github.com/actions/checkout/issues/760#issuecomment-1097501613