### PR TITLE
fix: detection of existing prs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -164,9 +164,11 @@ sync() {
 
         if [ $dry_run = "false" ]; then
 
-            pr_exists=$(gh pr view --json number --jq ".number" $stashed_template &>/dev/null; echo $?;)
+            pr_number=$(gh pr view --json number --jq ".number" $stashed_template)
+            pr_exists=$(echo $?)
+            pr_merged=$(gh api repos/{owner}/{repo}/pulls/$pr_number/merge &>/dev/null; echo $?;)
 
-            if [ $pr_exists == 0 ]; then
+            if [ $pr_exists == 0 ] && [ $pr_merged != 0 ]; then
 
                 branch_changes=$(git diff --exit-code origin/$stashed_template stash@{0} &>/dev/null; echo $?;)
 


### PR DESCRIPTION
We are looking for pr by branch name, and old prs with the same branch name where preventing the new pull request to be created
